### PR TITLE
use space as leader

### DIFF
--- a/plugin/common-settings.vim
+++ b/plugin/common-settings.vim
@@ -3,7 +3,7 @@ set nocompatible
 " Common Leader Key:
 " If .vimrc hasn't set it to anything, then default to ,
 if !exists('g:mapleader')
-  let g:mapleader=','
+  let g:mapleader="\<space>"
 endif
 
 " Use System Clipboard By Default:


### PR DESCRIPTION
If you're going to re-define the leader, I think it's a terrible idea to override helpful commands. `;` will repeat the last search from `f`, `F`, `t`, or `T`, and `,` does the same but in the opposite direction as the original search. These are part of the core functionality of vim.
`<space>` is hence a much better candidate for `<leader>` since it's just a synonym for `l`, and has the benefit of making your user mappings much more accessible compared to `,`.

<small>_Edited some words_</small>
